### PR TITLE
Silence warnings.

### DIFF
--- a/lib/multi_xml.rb
+++ b/lib/multi_xml.rb
@@ -180,14 +180,14 @@ module MultiXml
       case value
       when Hash
         if value['type'] == 'array'
-          _, entries = value.detect {|key, value| key != 'type'}
+          _, entries = value.detect {|key, _| key != 'type'}
 
           if entries.nil? || (entries.is_a?(String) && entries.strip.empty?)
             []
           else
             case entries
             when Array
-              entries.map{|value| typecast_xml_value(value)}
+              entries.map {|entry| typecast_xml_value(entry)}
             when Hash
               [typecast_xml_value(entries)]
             else
@@ -212,8 +212,8 @@ module MultiXml
         elsif value['type'] && value.size == 1 && !value['type'].is_a?(Hash)
           nil
         else
-          xml_value = value.inject({}) do |hash, (key, value)|
-            hash[key] = typecast_xml_value(value)
+          xml_value = value.inject({}) do |hash, (k, v)|
+            hash[k] = typecast_xml_value(v)
             hash
           end
 

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,6 +1,3 @@
-$:.unshift File.expand_path('..', __FILE__)
-$:.unshift File.expand_path('../../lib', __FILE__)
 require 'simplecov'
 SimpleCov.start
 require 'multi_xml'
-require 'rspec'

--- a/spec/multi_xml_spec.rb
+++ b/spec/multi_xml_spec.rb
@@ -7,9 +7,9 @@ describe "MultiXml" do
   context "Parsers" do
     it "should default to the best available gem" do
       pending
-      MultiXml.parser.name.should == 'MultiXml::Parsers::Rexml'
+      MultiXml.parser.name.should be == 'MultiXml::Parsers::Rexml'
       require 'nokogiri'
-      MultiXml.parser.name.should == 'MultiXml::Parsers::Nokogiri'
+      MultiXml.parser.name.should be == 'MultiXml::Parsers::Nokogiri'
       require 'libxml'
       MultiXml.parser.name.should == 'MultiXml::Parsers::Libxml'
     end

--- a/spec/parser_shared_example.rb
+++ b/spec/parser_shared_example.rb
@@ -86,8 +86,8 @@ shared_examples_for "a parser" do |parser|
         end
 
         it "should return the correct attributes" do
-          MultiXml.parse(@xml)['user']['name'].should == "Erik Michaels-Ober"
-          MultiXml.parse(@xml)['user']['screen_name'].should == "sferik"
+          MultiXml.parse(@xml)['user']['name'].should be == "Erik Michaels-Ober"
+          MultiXml.parse(@xml)['user']['screen_name'].should be == "sferik"
         end
       end
 


### PR DESCRIPTION
A few small changes to prevent multi_xml's code from generating warnings when the specs are run with -w.

This patch only affects multi_xml, it's dependencies (bundler, rspec, simplecov, etc) still generate warnings.
