### PR TITLE
Fixed regression in MultiXml.parse

### DIFF
--- a/lib/multi_xml.rb
+++ b/lib/multi_xml.rb
@@ -59,6 +59,7 @@ module MultiXml
     def parser
       return @@parser if defined?(@@parser)
       self.parser = self.default_parser
+      @@parser
     end
 
     # The default parser based on what you currently


### PR DESCRIPTION
This was caused by 6804ffc8680ed6466c66f2472f5e016c412c2c24.

When calling `MultiXml.parse` without setting a parser before, this would cause errors like:

```
MultiXml::ParseError: undefined method `parse' for :ox:Symbol
```

PS: This seems to be a strange "bug" in Ruby that would cause `.parse` to return the return value of `.default_parser` instead of `.parser=`.
