### PR TITLE
Reset @@parser in between specs

### DIFF
--- a/lib/multi_xml.rb
+++ b/lib/multi_xml.rb
@@ -57,7 +57,7 @@ module MultiXml
   class << self
     # Get the current parser class.
     def parser
-      return @@parser if defined?(@@parser)
+      return @@parser unless @@parser.nil?
       self.parser = self.default_parser
       @@parser
     end

--- a/spec/multi_xml_spec.rb
+++ b/spec/multi_xml_spec.rb
@@ -5,6 +5,10 @@ class MockDecoder; end
 
 describe "MultiXml" do
   context "Parsers" do
+    before do
+      MultiXml.send :class_variable_set, :@@parser, nil
+    end
+
     it "should pick a default parser" do
       MultiXml.parser.should be_kind_of(Module)
       MultiXml.parser.should respond_to(:parse)


### PR DESCRIPTION
This fixes specs on JRuby.

I did change the check in `#parser` to test for `nil` instead of using `defined?` to be able to reset the parser.
