### PR TITLE
Updated the content nodes to include attributes (Fixes issue #26)

### DIFF
--- a/lib/multi_xml.rb
+++ b/lib/multi_xml.rb
@@ -226,9 +226,19 @@ module MultiXml
         elsif value.has_key?(CONTENT_ROOT)
           content = value[CONTENT_ROOT]
           if block = PARSING[value['type']]
-            block.arity == 1 ? block.call(content) : block.call(content, value)
+            if block.arity == 1
+              value.delete('type') if PARSING[value['type']]
+              if value.keys.size > 1
+                value[CONTENT_ROOT] = block.call(content)
+                value
+              else
+                block.call(content)
+              end
+            else
+              block.call(content, value)
+            end
           else
-            content
+            value.keys.size > 1 ? value : content
           end
         elsif value['type'] == 'string' && value['nil'] != 'true'
           ''


### PR DESCRIPTION
I added the attributes to the hash for nodes that have actual content in them where we were losing these attributes before.

When the attribute key is 'type' and the value is in the PARSING array the value of the content is type casted just like before, and when type is the only attribute, the typecasted value is the only thing returned for that node (just like before).  However if there are other attributes those attributes get put onto a hash and the value stays on the **content** key.  If the type attribute is not typecast-able then the type attribute stays on the hash and the **content** is just passed through as a string.

examples:

```
<value type='integer'>123</value> 
#=> {'value' => 123'}

<value type='USD'>123></value> 
#=> {'value' => {'__content__' => '123', 'type' => 'USD'}}

<value currency='USD' type='integer'>123</value> 
#=> {'value' => {'__content__' => 123, 'currency' => 'USD'}}

<value currency='USD'>123</value> 
#=> {'value' => {'__content__' => '123', 'currency' => 'USD'}}

<value currency='USD' type='money'>123</value> 
#=> {'value' => {'__content__' => 123, 'currency' => 'USD', 'type' => 'money'}}
```

Let me know if I am missing anything here or if the specs are incomplete.

This should fix issue #26 as well as issue #1.  However, like we discussed in the ticket this is not a backwards compatible change.  That could be accomplished with an option on MultiXml.parse but we decided not to do that.

Thanks,
~ Tom
