### PR TITLE
Don't typecast parsed document if I want

### DIFF
--- a/spec/parser_shared_example.rb
+++ b/spec/parser_shared_example.rb
@@ -89,6 +89,37 @@ shared_examples_for "a parser" do |parser|
         end
       end
 
+      context "typecast management" do
+        before do
+          @xml = %Q{
+            <global-settings>
+              <group>
+                <name>Settings</name>
+                <setting type="string">
+                  <description>Test</description>
+                </setting>
+              </group>
+            </global-settings>
+          }
+        end
+
+        context "with :typecast_xml_value => true" do
+          before do
+            @setting = MultiXml.parse(@xml)["global_settings"]["group"]["setting"]
+          end
+
+          it { expect(@setting).to eq "" }
+        end
+
+        context "with :typecast_xml_value => false" do
+          before do
+            @setting = MultiXml.parse(@xml, :typecast_xml_value => false)["global_settings"]["group"]["setting"]
+          end
+
+          it { expect(@setting).to eq({"type"=>"string", "description"=>{"__content__"=>"Test"}}) }
+        end
+      end
+
       context "with :symbolize_keys => true" do
         before do
           @xml = '<user><name>Erik Michaels-Ober</name></user>'


### PR DESCRIPTION
The brief history why I've commited it - I can't parse properly document like this:

``` xml
<global-settings>
    <group>
        <name>Settings</name>
        <setting id="host_api_key" type="string" default-value="">
            <name>Host API Key</name>
            <description>Test</description>
        </setting>
    </group>
</global-settings>
```

``` ruby
=> MultiXml.parse(xml)
=> {"global_settings"=>
  {"group"=>{"name"=>"Global CloudFlare Settings", "setting"=>""}}}
```
