### PR TITLE
Fix Nokogiri parser for the same attr and inner element name

### DIFF
--- a/lib/multi_xml/parsers/libxml2_parser.rb
+++ b/lib/multi_xml/parsers/libxml2_parser.rb
@@ -35,7 +35,15 @@ module MultiXml
         end
 
         # Handle attributes
-        each_attr(node) {|a| node_hash[node_name(a)] = a.value }
+        each_attr(node) do |a|
+          key = node_name(a)
+
+          node_hash[key] = if v = node_hash[key]
+                             [a.value, v]
+                           else
+                             a.value
+                           end
+        end
 
         hash
       end

--- a/spec/parser_shared_example.rb
+++ b/spec/parser_shared_example.rb
@@ -58,6 +58,16 @@ shared_examples_for "a parser" do |parser|
         end
       end
 
+      context "element with the same inner element and attribute name" do
+        before do
+          @xml = "<user name='John'><name>Smith</name></user>"
+        end
+
+        it "returns nams as Array" do
+          expect(MultiXml.parse(@xml)['user']['name']).to eq ['John', 'Smith']
+        end
+      end
+
       context "with content" do
         before do
           @xml = '<user>Erik Michaels-Ober</user>'


### PR DESCRIPTION
Say we have this xml:

``` xml
<user name='John'><name>Smith</name></user>
```

All parsers give result: `{'user' => {'name' => ['John', 'Smith']}`
But nokogiri parser loses inner element: `{'user' => {'name' => 'John'}}`

This fix solves this issue.
