### PR TITLE
Duplexed streams

### DIFF
--- a/spec/parser_shared_example.rb
+++ b/spec/parser_shared_example.rb
@@ -3,6 +3,10 @@ shared_examples_for 'a parser' do |parser|
   before do
     begin
       MultiXml.parser = parser
+
+      if parser == 'LibXML'
+        LibXML::XML::Error.set_handler(&LibXML::XML::Error::QUIET_HANDLER)
+      end
     rescue LoadError
       pending "Parser #{parser} couldn't be loaded"
     end

--- a/spec/parser_shared_example.rb
+++ b/spec/parser_shared_example.rb
@@ -697,13 +697,6 @@ shared_examples_for 'a parser' do |parser|
       before do
         @xml, wr = IO.pipe
 
-        # Trick Ox to read IO partially.
-        #
-        # https://github.com/ohler55/ox/blob/569e58ecc7b5a3f24ef27369c578fc721b26d775/ext/ox/sax_buf.c#L41
-        if parser == "Ox"
-          class << @xml; undef_method :fileno; end
-        end
-
         Thread.new {
           '<user/>'.each_char do |chunk|
             wr << chunk


### PR DESCRIPTION
I'm adding test coverage for duplexed IO streams.

I ran into an issue with the Ox wrapper and included a workaround [in the spec][1]. All other wrappers work fine.

cc: @ohler55

[1]: https://github.com/hakanensari/multi_xml/commit/c5a24f943affd121e208bdfae57c1c7260f07fb1