### PR TITLE
Freeze "tr" arguments

### DIFF
--- a/lib/multi_xml.rb
+++ b/lib/multi_xml.rb
@@ -199,7 +199,7 @@ module MultiXml # rubocop:disable ModuleLength
       case params
       when Hash
         params.inject({}) do |hash, (key, value)|
-          hash[key.to_s.tr('-', '_')] = undasherize_keys(value)
+          hash[key.to_s.tr('-'.freeze, '_'.freeze)] = undasherize_keys(value)
           hash
         end
       when Array


### PR DESCRIPTION
For memory efficiency on Ruby 2.1+; these make up a significant chunk of allocations for some jobs in our Rails app, according to the memory_profiler gem, since this method is called a lot.

I didn't add specs or docs because I'm not sure what would apply, but I'm happy to if there's a specific request.

If this pull request is received favorably I may follow up with one that moves the string "type" out to a constant - let me know if that sounds like a good idea.