### PR TITLE
Add test for parsing frozen string and fixed related bug

### DIFF
--- a/lib/multi_xml.rb
+++ b/lib/multi_xml.rb
@@ -132,7 +132,7 @@ module MultiXml # rubocop:disable ModuleLength
 
       options = DEFAULT_OPTIONS.merge(options)
 
-      xml.strip! if xml.respond_to?(:strip!)
+      xml = xml.strip if xml.respond_to?(:strip)
       begin
         xml = StringIO.new(xml) unless xml.respond_to?(:read)
 

--- a/spec/parser_shared_example.rb
+++ b/spec/parser_shared_example.rb
@@ -32,6 +32,16 @@ shared_examples_for 'a parser' do |parser|
       end
     end
 
+    context 'a frozen string' do
+      before do
+        @xml = ' '.freeze
+      end
+
+      it 'returns an empty Hash' do
+        expect(MultiXml.parse(@xml)).to eq({})
+      end
+    end
+
     unless parser == 'Oga'
       context 'an invalid XML document' do
         before do


### PR DESCRIPTION
In Ruby 3.0 Matz has said literal strings will be frozen/immutable. In preparation for this Rubocop's autofix is already inserting the new Ruby 2.3 magic comment `# frozen_string_literal: true` which freezes literal strings - http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/FrozenStringLiteralComment

The need to parse frozen strings will certainly become more common. So I added the required test example and fixed MultiXML to pass this test. 
