### PR TITLE
Integer Unification for Ruby 2.4.0+

### DIFF
--- a/lib/multi_xml.rb
+++ b/lib/multi_xml.rb
@@ -48,8 +48,7 @@ module MultiXml # rubocop:disable ModuleLength
 
   TYPE_NAMES = {
     'Symbol'     => 'symbol',
-    'Fixnum'     => 'integer',
-    'Bignum'     => 'integer',
+    'Integer'    => 'integer',
     'BigDecimal' => 'decimal',
     'Float'      => 'float',
     'TrueClass'  => 'boolean',

--- a/spec/parser_shared_example.rb
+++ b/spec/parser_shared_example.rb
@@ -182,8 +182,8 @@ shared_examples_for 'a parser' do |parser|
             @xml = '<tag type="integer">1</tag>'
           end
 
-          it 'returns a Fixnum' do
-            expect(MultiXml.parse(@xml)['tag']).to be_a(Fixnum)
+          it 'returns a Integer' do
+            expect(MultiXml.parse(@xml)['tag']).to be_a(Integer)
           end
 
           it 'returns a positive number' do
@@ -200,8 +200,8 @@ shared_examples_for 'a parser' do |parser|
             @xml = '<tag type="integer">-1</tag>'
           end
 
-          it 'returns a Fixnum' do
-            expect(MultiXml.parse(@xml)['tag']).to be_a(Fixnum)
+          it 'returns a Integer' do
+            expect(MultiXml.parse(@xml)['tag']).to be_a(Integer)
           end
 
           it 'returns a negative number' do


### PR DESCRIPTION
Ruby 2.4.0 unifies Fixnum and Bignum into Integer.

https://bugs.ruby-lang.org/issues/12005

Fix following deprecated warnings in Ruby 2.4.0-preview3.

- `warning: constant ::Fixnum is deprecated`
- `warning: constant ::Bignum is deprecated`

Thanks.