### PR TITLE
Dropped support for Ruby 1.9.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1
   - 2.2

--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ then Nokogiri, and finally REXML.
 This library aims to support and is [tested against][travis] the following Ruby
 implementations:
 
-* Ruby 1.9.3
 * Ruby 2.0.0
 * Ruby 2.1
 * Ruby 2.2


### PR DESCRIPTION
I propose to dropped support for Ruby 1.9.3.

These are the reasons below.

- [`bundle install` failed using Ruby 1.9.3](https://travis-ci.org/sferik/multi_xml/jobs/181376717), because a dependency gem requires Ruby version >= 2.0.
- [Ruby 1.9.3 was EOL](https://www.ruby-lang.org/en/news/2015/02/23/support-for-ruby-1-9-3-has-ended)

Thanks.