### PR TITLE
Travis: update rubies, make lint pass

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,6 @@
 AllCops:
+  TargetRubyVersion: '2.2.2'
+  DisplayCopNames: true
   Exclude:
     - 'spec/speed.rb'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ env:
     - JRUBY_OPTS="$JRUBY_OPTS --debug"
 language: ruby
 rvm:
-  - 2.2.6
-  - 2.3.3
-  - 2.4.0
-  - jruby-9.1.7.0
+  - 2.2.7
+  - 2.3.4
+  - 2.4.1
+  - jruby-9.1.8.0
   - jruby-head
   - ruby-head
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
-  - jruby-9.1.8.0
+  - jruby-9.1.14.0
   - jruby-head
   - ruby-head
 matrix:

--- a/Rakefile
+++ b/Rakefile
@@ -30,4 +30,4 @@ Yardstick::Rake::Verify.new do |verify|
   verify.threshold = 48.8
 end
 
-task default: [:spec, :rubocop, :verify_measurements]
+task default: %i[spec rubocop verify_measurements]

--- a/lib/multi_xml.rb
+++ b/lib/multi_xml.rb
@@ -39,7 +39,7 @@ module MultiXml # rubocop:disable ModuleLength
       'float'        => float_proc,
       'double'       => float_proc,
       'decimal'      => proc { |number| BigDecimal(number) },
-      'boolean'      => proc { |boolean| !%w(0 false).include?(boolean.strip) },
+      'boolean'      => proc { |boolean| !%w[0 false].include?(boolean.strip) },
       'string'       => proc { |string| string.to_s },
       'yaml'         => proc { |yaml| YAML.load(yaml) rescue yaml }, # rubocop:disable RescueModifier, YAMLLoad
       'base64Binary' => proc { |binary| ::Base64.decode64(binary) },
@@ -64,7 +64,7 @@ module MultiXml # rubocop:disable ModuleLength
     }.freeze
   end
 
-  DISALLOWED_XML_TYPES = %w(symbol yaml).freeze
+  DISALLOWED_XML_TYPES = %w[symbol yaml].freeze
 
   DEFAULT_OPTIONS = {
     typecast_xml_value: true,

--- a/multi_xml.gemspec
+++ b/multi_xml.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'multi_xml/version'
@@ -8,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.author = 'Erik Michaels-Ober'
   spec.description = 'Provides swappable XML backends utilizing LibXML, Nokogiri, Ox, or REXML.'
   spec.email = 'sferik@gmail.com'
-  spec.files = %w(.yardopts CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md multi_xml.gemspec) + Dir['lib/**/*.rb']
+  spec.files = %w[.yardopts CHANGELOG.md CONTRIBUTING.md LICENSE.md README.md multi_xml.gemspec] + Dir['lib/**/*.rb']
   spec.homepage = 'https://github.com/sferik/multi_xml'
   spec.licenses = ['MIT']
   spec.name = 'multi_xml'

--- a/spec/multi_xml_spec.rb
+++ b/spec/multi_xml_spec.rb
@@ -34,11 +34,11 @@ describe 'MultiXml' do
     end
   end
 
-  [%w(LibXML libxml),
-   %w(REXML rexml/document),
-   %w(Nokogiri nokogiri),
-   %w(Ox ox),
-   %w(Oga oga)].each do |parser|
+  [%w[LibXML libxml],
+   %w[REXML rexml/document],
+   %w[Nokogiri nokogiri],
+   %w[Ox ox],
+   %w[Oga oga]].each do |parser|
     begin
       require parser.last
       context "#{parser.first} parser" do

--- a/spec/parser_shared_example.rb
+++ b/spec/parser_shared_example.rb
@@ -79,7 +79,7 @@ shared_examples_for 'a parser' do |parser|
         end
 
         it 'returns names as Array' do
-          expect(MultiXml.parse(@xml)['user']['name']).to eq %w(John Smith)
+          expect(MultiXml.parse(@xml)['user']['name']).to eq %w[John Smith]
         end
       end
 
@@ -156,7 +156,7 @@ shared_examples_for 'a parser' do |parser|
       end
 
       context 'with an attribute type="boolean"' do
-        %w(true false).each do |boolean|
+        %w[true false].each do |boolean|
           context "when #{boolean}" do
             it "returns #{boolean}" do
               xml = "<tag type=\"boolean\">#{boolean}</tag>"
@@ -436,7 +436,7 @@ shared_examples_for 'a parser' do |parser|
         end
       end
 
-      %w(integer boolean date datetime file).each do |type|
+      %w[integer boolean date datetime file].each do |type|
         context "with an empty attribute type=\"#{type}\"" do
           before do
             @xml = "<tag type=\"#{type}\"/>"
@@ -448,7 +448,7 @@ shared_examples_for 'a parser' do |parser|
         end
       end
 
-      %w(yaml symbol).each do |type|
+      %w[yaml symbol].each do |type|
         context "with an empty attribute type=\"#{type}\"" do
           before do
             @xml = "<tag type=\"#{type}\"/>"


### PR DESCRIPTION
This PR updates the Ruby versions used to latest releases, which are currently:

- 2.2.7
- 2.3.4
- 2.4.1
- jruby-9.1.8.0

---

Also: auto-fixed with new Rubocop style rules.
