### PR TITLE
Update for ox > 2.4.11

### DIFF
--- a/lib/multi_xml/parsers/ox.rb
+++ b/lib/multi_xml/parsers/ox.rb
@@ -29,7 +29,7 @@ module MultiXml
 
       def parse(io)
         handler = Handler.new
-        ::Ox.sax_parse(handler, io, convert_special: true)
+        ::Ox.sax_parse(handler, io, convert_special: true, skip: :skip_return)
         handler.doc
       end
 


### PR DESCRIPTION
There is more pedantic parsing of white-space characters in ox > 2.4.11, which causes the tests are failing. Better to set explicitly the expected skip mode.