### PR TITLE
Travis: jruby-9.1.14.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
-  - jruby-9.1.7.0
+  - jruby-9.1.13.0
   - jruby-head
   - ruby-head
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rvm:
   - 2.2.6
   - 2.3.3
   - 2.4.0
-  - jruby-9.1.13.0
+  - jruby-9.1.14.0
   - jruby-head
   - ruby-head
 matrix:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/11/08/jruby-9-1-14-0.html