### PR TITLE
Add frozen string literal comment and remove string mutation

### DIFF
--- a/lib/multi_xml.rb
+++ b/lib/multi_xml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'base64'
 require 'bigdecimal'
 require 'date'

--- a/lib/multi_xml/parsers/libxml.rb
+++ b/lib/multi_xml/parsers/libxml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'libxml' unless defined?(LibXML)
 require 'multi_xml/parsers/libxml2_parser'
 

--- a/lib/multi_xml/parsers/libxml2_parser.rb
+++ b/lib/multi_xml/parsers/libxml2_parser.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module MultiXml
   module Parsers
     module Libxml2Parser #:nodoc:
@@ -28,7 +30,7 @@ module MultiXml
           if c.element?
             node_to_hash(c, node_hash)
           elsif c.text? || c.cdata?
-            node_hash[MultiXml::CONTENT_ROOT] << c.content
+            node_hash[MultiXml::CONTENT_ROOT] += c.content
           end
         end
 

--- a/lib/multi_xml/parsers/nokogiri.rb
+++ b/lib/multi_xml/parsers/nokogiri.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri' unless defined?(Nokogiri)
 require 'multi_xml/parsers/libxml2_parser'
 

--- a/lib/multi_xml/parsers/oga.rb
+++ b/lib/multi_xml/parsers/oga.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'oga' unless defined?(Oga)
 require 'multi_xml/parsers/libxml2_parser'
 
@@ -36,7 +38,7 @@ module MultiXml
           if c.is_a?(::Oga::XML::Element)
             node_to_hash(c, node_hash)
           elsif c.is_a?(::Oga::XML::Text) || c.is_a?(::Oga::XML::Cdata)
-            node_hash[MultiXml::CONTENT_ROOT] << c.text
+            node_hash[MultiXml::CONTENT_ROOT] += c.text
           end
         end
 

--- a/lib/multi_xml/parsers/ox.rb
+++ b/lib/multi_xml/parsers/ox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ox' unless defined?(Ox)
 
 # Each MultiXml parser is expected to parse an XML document into a Hash. The

--- a/lib/multi_xml/parsers/rexml.rb
+++ b/lib/multi_xml/parsers/rexml.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rexml/document' unless defined?(REXML::Document)
 
 module MultiXml
@@ -56,8 +58,7 @@ module MultiXml
       def merge_texts!(hash, element)
         if element.has_text?
           # must use value to prevent double-escaping
-          texts = ''
-          element.texts.each { |t| texts << t.value }
+          texts = element.texts.reduce('') { |acc, t| acc + t.value }
           merge!(hash, MultiXml::CONTENT_ROOT, texts)
         else
           hash


### PR DESCRIPTION
@sferik Hi!
Currently `multi_xml` heavily mutates strings, which prevents any code that depends on it from running with `RUBYOPT="--enable-frozen-string-literal"` environmental variable