### PR TITLE
Include REXML

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,7 @@ gem 'libxml-ruby', require: nil, platforms: :ruby
 gem 'nokogiri', require: nil
 gem 'oga', '>= 2.3', require: nil
 gem 'ox', require: nil, platforms: :ruby
+gem 'rexml', require: nil
 
 group :development do
   gem 'kramdown'


### PR DESCRIPTION
In Ruby 3.0, REXML mas moved from StdLib to bundled gems, therefore this is needed to pass the test suite.