### PR TITLE
Ruby 3.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.0', '3.1', '3.2']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
 
     steps:
     - uses: actions/checkout@v3
@@ -30,7 +30,7 @@ jobs:
     # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
     # change this to (see https://github.com/ruby/setup-ruby#versioning):
     # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@55283cc23133118229fd3f97f9336ee23a179fcf # v1.146.0
+      uses: ruby/setup-ruby@360dc864d5da99d54fcb8e9148c14a84b90d3e88 # v1.165.1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/multi_xml.gemspec
+++ b/multi_xml.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |spec|
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
   spec.metadata["rubygems_mfa_required"] = "true"
+
+  spec.add_runtime_dependency("bigdecimal")
 end


### PR DESCRIPTION
Test against Ruby 3.3 and supress new warnings.

Ruby 3.3 will warn if base64 or bigdecimal is required without requiring it in the gemspec. The base64 gem is trivial to replace, but bigdecimal I added to the gemspec.

base64:
* https://github.com/rack/rack/pull/2110
* https://github.com/rubocop/rubocop/pull/12313
* https://github.com/newrelic/newrelic-ruby-agent/pull/2378
* https://github.com/lostisland/faraday/pull/1541

bigdecimal:
* https://github.com/rails/rails/pull/49039