### PR TITLE
Add bigdecimal gem as dependency

### DIFF
--- a/multi_xml.gemspec
+++ b/multi_xml.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |spec|
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html
   spec.metadata["rubygems_mfa_required"] = "true"
+
+  spec.add_dependency 'bigdecimal'
 end


### PR DESCRIPTION
bigdecimal will not longer be included as a default gem in ruby 3.4.0

>multi_xml.rb:2: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of multi_xml-0.6.0 to add bigdecimal into its gemspec.

This patch will fix the warning from displaying while running ruby 3.3.0